### PR TITLE
Change JIRA url to open gerrit-plugin tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Gerrit Code Review plugin for Jenkins
 
 * see [Jenkins wiki](https://wiki.jenkins.io/display/JENKINS/Gerrit+Code+Review+Plugin) for detailed feature descriptions
-* use [JIRA](https://issues.jenkins-ci.org) to report issues / feature requests
+* use [JIRA](https://issues.jenkins-ci.org/issues/?jql=component%20%3D%20gerrit-code-review-plugin%20and%20resolution%20is%20empty) to report issues / feature requests
 
 ## Master Branch
 
@@ -11,7 +11,7 @@ The master branch is the primary development branch for the Gerrit Code Review p
 
 ## Contributing to the Plugin
 
-Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/gerrit-plugin).
+Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/gerrit-code-review-plugin).
 New feature proposals and bug fix proposals should be submitted as
 [pull requests](https://help.github.com/articles/creating-a-pull-request).
 Fork the repository, prepare your change on your forked
@@ -27,4 +27,3 @@ a test which verifies your change.
   $ mvn -version # Need a modern maven version; maven 3.2.5 and 3.5.0 are known to work
   $ mvn clean install
 ```
-


### PR DESCRIPTION
New URL will point users to the list of open bugs of the gerrit-plugin, instead of just sending them to the JIRA.