### PR TITLE
build: prepare for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   </licenses>
 
   <artifactId>gerrit-code-review</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Gerrit Code Review plugin</name>
   <description>Integrates Jenkins with Gerrit Code Review</description>


### PR DESCRIPTION
Jenkins Maven release plugin requires -SNAPSHOT versions in order to allow you to run:
mvn release:prepare release:perform