### PR TITLE
Support Gerrit deployments behind a reverse proxy

### DIFF
--- a/src/main/java/jenkins/plugins/gerrit/GerritURI.java
+++ b/src/main/java/jenkins/plugins/gerrit/GerritURI.java
@@ -1,0 +1,101 @@
+package jenkins.plugins.gerrit;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jgit.transport.URIish;
+
+/**
+ * A GerritURI encapsulates a Gerrit remote URI and is able to extract certain properties like the project name and URI
+ * prefix.
+ */
+public class GerritURI {
+
+  private static enum Scheme {
+    HTTP,
+    HTTPS,
+    SSH
+  }
+
+  /**
+   * Pattern which matches the URI prefix and the project name of a Gerrit HTTP URI.
+   */
+  private static final Pattern GERRIT_HTTP_URI_PATTERN = Pattern.compile("(.*?)/a/(.*)");
+
+  private final URIish remoteURI;
+
+  /**
+   * Create a new Gerrit URI from the given remote {@link URIish URI}.
+   *
+   * @param remoteURI the remote URI, e.g. https://host/a/project
+   */
+  public GerritURI(URIish remoteURI) {
+    this.remoteURI = remoteURI;
+  }
+
+  /**
+   * Get the full Gerrit remote URI.
+   *
+   * @return the remote URI
+   */
+  public URIish getRemoteURI() {
+    return remoteURI;
+  }
+
+  /**
+   * Get the Gerrit project name from the remote URI.
+   *
+   * @return the Gerrit project name
+   */
+  public String getProject() {
+    Scheme scheme = getScheme(remoteURI.getScheme());
+    switch (scheme) {
+      case HTTP:
+      case HTTPS:
+        Matcher matcher = GERRIT_HTTP_URI_PATTERN.matcher(remoteURI.getRawPath());
+        if (!matcher.matches()) {
+          throw new IllegalArgumentException("Unable to determine Gerrit project from remote " + remoteURI);
+        }
+
+        return matcher.group(2);
+      case SSH:
+        return remoteURI.getRawPath().substring(1);
+      default:
+        throw new IllegalStateException("Unknown scheme " + scheme);
+    }
+  }
+
+  /**
+   * Get the URI prefix from the remote URI.
+   *
+   * @return the URI prefix, e.g. /gerrit/ when Gerrit is configured with httpd.listenUrl
+   *     protocol://host:port/gerrit/.
+   */
+  public String getPrefix() {
+    Scheme scheme = getScheme(remoteURI.getScheme());
+    switch (scheme) {
+      case HTTP:
+      case HTTPS:
+        Matcher matcher = GERRIT_HTTP_URI_PATTERN.matcher(remoteURI.getRawPath());
+        if (!matcher.matches()) {
+          throw new IllegalArgumentException("Unable to determine Gerrit prefix from remote " + remoteURI);
+        }
+
+        return matcher.group(1);
+      case SSH:
+        return "";
+      default:
+        throw new IllegalStateException("Unknown scheme " + scheme);
+    }
+  }
+
+  private Scheme getScheme(String value) {
+    for (Scheme scheme : Scheme.values()) {
+      if (scheme.name().equalsIgnoreCase(value)) {
+        return scheme;
+      }
+    }
+    throw new IllegalArgumentException("Unknown scheme " + value);
+  }
+
+}

--- a/src/test/java/jenkins/plugins/gerrit/GerritURITest.java
+++ b/src/test/java/jenkins/plugins/gerrit/GerritURITest.java
@@ -1,0 +1,62 @@
+package jenkins.plugins.gerrit;
+
+import static org.junit.Assert.*;
+
+import java.net.URISyntaxException;
+
+import org.eclipse.jgit.transport.URIish;
+import org.junit.Test;
+
+public class GerritURITest {
+
+  @Test
+  public void projectNameWithSlashesIsExtractedFromHTTPURI() throws URISyntaxException {
+    GerritURI gerritURI = new GerritURI(new URIish("http://host/a/project/with/slashes"));
+
+    assertEquals("project/with/slashes", gerritURI.getProject());
+  }
+
+  @Test
+  public void firstAInURIIsConsideredTheProjectMarker() throws URISyntaxException {
+    GerritURI gerritURI = new GerritURI(new URIish("http://host/prefix/a/project/a/suffix"));
+
+    assertEquals("/prefix", gerritURI.getPrefix());
+    assertEquals("project/a/suffix", gerritURI.getProject());
+  }
+
+  @Test
+  public void projectNameWithSlashesIsExtractedFromHTTPSURI() throws URISyntaxException {
+    GerritURI gerritURI = new GerritURI(new URIish("https://host/a/project/with/slashes"));
+
+    assertEquals("project/with/slashes", gerritURI.getProject());
+  }
+
+  @Test
+  public void projectNameWithSlashesIsExtractedFromSSHURI() throws URISyntaxException {
+    GerritURI gerritURI = new GerritURI(new URIish("ssh://username@host:29418/project/with/slashes"));
+
+    assertEquals("project/with/slashes", gerritURI.getProject());
+  }
+
+  @Test
+  public void prefixWithSlashesIsExtractedFromHTTPURI() throws URISyntaxException {
+    GerritURI gerritURI = new GerritURI(new URIish("http://host/prefix/with/slashes/a/project"));
+
+    assertEquals("/prefix/with/slashes", gerritURI.getPrefix());
+  }
+
+  @Test
+  public void prefixWithSlashesIsExtractedFromHTTPSURI() throws URISyntaxException {
+    GerritURI gerritURI = new GerritURI(new URIish("https://host/prefix/with/slashes/a/project"));
+
+    assertEquals("/prefix/with/slashes", gerritURI.getPrefix());
+  }
+
+  @Test
+  public void prefixOfSSHURIIsAlwaysEmpty() throws URISyntaxException {
+    GerritURI gerritURI = new GerritURI(new URIish("ssh://username@host:29418/project/with/slashes"));
+
+    assertEquals("", gerritURI.getPrefix());
+  }
+
+}


### PR DESCRIPTION
Currently the plugin only supports Gerrit deployments which are hosted
at the root of a domain and deployments behind a reverse proxy with an
alternative URI prefix (like https://host/gerrit/) aren't supported.

This is fixed by parsing the Gerrit URI and extracting both the URI
prefix and the project name.