### PR TITLE
prefer "gerrit" symbol name

### DIFF
--- a/src/main/java/jenkins/plugins/gerrit/GerritSCMSource.java
+++ b/src/main/java/jenkins/plugins/gerrit/GerritSCMSource.java
@@ -261,7 +261,7 @@ public class GerritSCMSource extends AbstractGerritSCMSource {
     return traits;
   }
 
-  @Symbol("git")
+  @Symbol({"gerrit","git"})
   @Extension
   public static class DescriptorImpl extends SCMSourceDescriptor {
 


### PR DESCRIPTION
symbol have to be unique for an extension point, and "git" is already (legitimately) used by https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/jenkins/plugins/git/GitSCMSource.java#L422

fix https://github.com/jenkinsci/configuration-as-code-plugin/issues/538