### PR TITLE
scm.buildChooser will contain the triggering commit

### DIFF
--- a/src/main/resources/jenkins/plugins/gerrit/workflow/Gerrit.groovy
+++ b/src/main/resources/jenkins/plugins/gerrit/workflow/Gerrit.groovy
@@ -31,7 +31,7 @@ class Gerrit implements Serializable {
     public void review(String label = 'Verified', int score = 0, String message = "") {
         node {
             if (script.env.BRANCH_NAME ==~ /[0-9][0-9]\/[0-9]+\/[0-9]+/) {
-                def sha1 = script.checkout(script.scm).GIT_COMMIT
+                def sha1 = script.scm.buildChooser.revision.getSha1String()
                 def changeId = script.env.BRANCH_NAME.split("/")[1]
                 def notify = score < 0 ? ', "notify" : "OWNER"' : ''
                 def jsonPayload = '{"labels":{"' + label + '":' + score + '},' +


### PR DESCRIPTION
In some cases checkout(this.scm).GIT_COMMIT will give you the sha1 of the branch not the the change causing gerrit.review() to fail.

e.x.:
- A Gerrit repo containing a pipeline library which is  defined as a global library in Jenkins
- Jenkins has a GerritMultiBranch job configured to build/test that repo
- Correct version will be checked out, but gerrit.review() will get the sha1 of master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/gerrit-code-review-plugin/10)
<!-- Reviewable:end -->
