### PR TITLE
Just a simple 'def' since we don't care about the object type

### DIFF
--- a/src/main/resources/jenkins/plugins/gerrit/workflow/Gerrit.groovy
+++ b/src/main/resources/jenkins/plugins/gerrit/workflow/Gerrit.groovy
@@ -77,7 +77,7 @@ class Gerrit implements Serializable {
         script.echo "Posting Gerrit Review ${jsonPayload} to ${uri}/${path}"
         GerritAuthData.Basic authData = new GerritAuthData.Basic(uri.setRawPath("/").toString(), script.USERNAME, script.PASSWORD);
         GerritRestApi gerritApi = new GerritRestApiFactory().create(authData, SSLNoVerifyCertificateManagerClientBuilderExtension.INSTANCE)
-        JsonElement result = gerritApi.restClient().postRequest(path, jsonPayload)
+        def result = gerritApi.restClient().postRequest(path, jsonPayload)
         script.echo "Result: ${result}"
         return result
     }


### PR DESCRIPTION
Jenkins instances with both gerrit-trigger and gerrit-code-review plugin can/will fail due to a classpath conflict caused by different versions of JsonElement dependency.

Changing this to 'def' since the result isn't used at all works with either version of the library found on the classpath.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/gerrit-code-review-plugin/11)
<!-- Reviewable:end -->
