### PR TITLE
Fix project name detection from URL

### DIFF
--- a/src/main/java/jenkins/plugins/gerrit/GerritURI.java
+++ b/src/main/java/jenkins/plugins/gerrit/GerritURI.java
@@ -17,9 +17,11 @@ public class GerritURI {
   }
 
   /** Pattern which matches the URI prefix and the project name of a Gerrit HTTP URI. */
-  private static final Pattern GERRIT_AUTH_HTTP_URI_PATTERN = Pattern.compile("(.*?)/a/(.*)");
+  private static final Pattern GERRIT_AUTH_HTTP_URI_PATTERN =
+      Pattern.compile("(.*?)/a/(.*)(\\.git)?");
 
-  private static final Pattern GERRIT_ANON_HTTP_URI_PATTERN = Pattern.compile("(.*?)/([^/]+)");
+  private static final Pattern GERRIT_ANON_HTTP_URI_PATTERN =
+      Pattern.compile("(.*?)/([^/\\.]+)(\\.git)?");
 
   private final URIish remoteURI;
 

--- a/src/test/java/jenkins/plugins/gerrit/GerritURITest.java
+++ b/src/test/java/jenkins/plugins/gerrit/GerritURITest.java
@@ -37,6 +37,13 @@ public class GerritURITest {
   }
 
   @Test
+  public void projectNameEndingWithDotGitIsExtractedFromHTTPURI() throws URISyntaxException {
+    GerritURI gerritURI = new GerritURI(new URIish("http://host/project.git"));
+
+    assertEquals("project", gerritURI.getProject());
+  }
+
+  @Test
   public void firstAInURIIsConsideredTheProjectMarker() throws URISyntaxException {
     GerritURI gerritURI = new GerritURI(new URIish("http://host/prefix/a/project/a/suffix"));
 


### PR DESCRIPTION
[FIX JENKINS-49692] and allow Gerrit project name extraction from URLs
that contain the '.git' suffix.

Examples of valida Gerrit URLs for a project called 'foo'
http://gerrit.mycompany.com/foo
http://gerrit.mycompany.com/foo.git