### PR TITLE
restapi: use gerrit server prefix

### DIFF
--- a/src/main/java/jenkins/plugins/gerrit/workflow/GerritCommentStep.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/GerritCommentStep.java
@@ -132,7 +132,7 @@ public class GerritCommentStep extends Step {
         throws URISyntaxException, RestApiException {
       echo("PUT Gerrit Review %s to %s%s", jsonPayload, uri, path);
       GerritAuthData.Basic authData =
-          new GerritAuthData.Basic(uri.setRawPath("/").toString(), username, password);
+          new GerritAuthData.Basic(uri.toString(), username, password);
       GerritRestApi gerritApi =
           new GerritRestApiFactory()
               .create(authData, SSLNoVerifyCertificateManagerClientBuilderExtension.INSTANCE);

--- a/src/main/java/jenkins/plugins/gerrit/workflow/GerritReviewStep.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/GerritReviewStep.java
@@ -128,7 +128,7 @@ public class GerritReviewStep extends Step {
         throws URISyntaxException, RestApiException {
       echo("Posting Gerrit Review %s to %s%s", jsonPayload, uri, path);
       GerritAuthData.Basic authData =
-          new GerritAuthData.Basic(uri.setRawPath("/").toString(), username, password);
+          new GerritAuthData.Basic(uri.toString(), username, password);
       GerritRestApi gerritApi =
           new GerritRestApiFactory()
               .create(authData, SSLNoVerifyCertificateManagerClientBuilderExtension.INSTANCE);

--- a/src/main/resources/jenkins/plugins/gerrit/workflow/Gerrit.groovy
+++ b/src/main/resources/jenkins/plugins/gerrit/workflow/Gerrit.groovy
@@ -67,7 +67,7 @@ class Gerrit implements Serializable {
                     script.scm.getRepositories().each {
                         String name = it.getName()
                         if (it.getName() == rname) {
-                            gerritApiPost(it.getURIs()[0], path, script.USERNAME, script.PASSWORD, jsonPayload)
+                            gerritApiPost(new GerritURI(it.getURIs()[0]).getApiURL(), path, script.USERNAME, script.PASSWORD, jsonPayload)
                         }
                     }
                 }
@@ -79,7 +79,7 @@ class Gerrit implements Serializable {
 
     private def gerritApiPost(URIish uri, String path, String username, String password, String jsonPayload) {
         script.echo "Posting Gerrit Review ${jsonPayload} to ${uri}/${path}"
-        GerritAuthData.Basic authData = new GerritAuthData.Basic(uri.setRawPath("/").toString(), script.USERNAME, script.PASSWORD);
+        GerritAuthData.Basic authData = new GerritAuthData.Basic(uri.toString(), script.USERNAME, script.PASSWORD);
         GerritRestApi gerritApi = new GerritRestApiFactory().create(authData, SSLNoVerifyCertificateManagerClientBuilderExtension.INSTANCE)
         def result = gerritApi.restClient().postRequest(path, jsonPayload)
         script.echo "Result: ${result}"


### PR DESCRIPTION
when gerrit has a prefix, such as https://server/gerrit the current
implementation is failing as it truncates the RestAPI path.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>