### PR TITLE
workflow: support no change of label

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ multi-branch pipeline job execution.
 Parameters:
 
 - ```label```
-  The review label to add to the Gerrit change.
+  If non-null, the review label to add to the Gerrit change.
   Default: 'Verified'.
 
 - ```score```

--- a/src/main/java/jenkins/plugins/gerrit/workflow/GerritReviewStep.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/GerritReviewStep.java
@@ -70,13 +70,16 @@ public class GerritReviewStep extends Step {
 
         String credentialsId = envVars.get("GERRIT_CREDENTIALS_ID");
         String gerritApiUrl = envVars.get("GERRIT_API_URL");
-        String notify = score < 0 ? ", \"notify\" : \"OWNER\"" : "";
-        String jsonPayload =
-            "{\"labels\":{\""
+        String labels = label == null ? "" :
+            "\"labels\":{\""
                 + label
                 + "\":"
                 + score
-                + "},"
+                + "},";
+        String notify = score < 0 ? ", \"notify\" : \"OWNER\"" : "";
+        String jsonPayload =
+                "{"
+                + labels
                 + " \"message\": \""
                 + message
                 + "\""


### PR DESCRIPTION
Support a simple comment that does not change the scores by setting label to
null.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>