### PR TITLE
workflow: disable integration if missing environment

### DIFF
--- a/src/main/java/jenkins/plugins/gerrit/workflow/GerritCommentStep.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/GerritCommentStep.java
@@ -73,7 +73,15 @@ public class GerritCommentStep extends Step {
 
     @Override
     protected Void run() throws Exception {
+      String gerritApiUrl = envVars.get("GERRIT_API_URL");
+      String credentialsId = envVars.get("GERRIT_CREDENTIALS_ID");
       String branch = envVars.get("BRANCH_NAME");
+
+      if (gerritApiUrl == null) {
+        echo("GERRIT_API_URL is not available, disabling Gerrit integration");
+        return null;
+      }
+
       Pattern changeBranchPattern = Pattern.compile("([0-9][0-9])/([0-9]+)/([0-9]+)");
       Matcher matcher = changeBranchPattern.matcher(branch);
       if (matcher.matches()) {
@@ -81,8 +89,6 @@ public class GerritCommentStep extends Step {
         int patchsetId = Integer.parseInt(matcher.group(3));
         echo("Gerrit comment on change %d %s:%d (%s)", changeId, path, line, message);
 
-        String credentialsId = envVars.get("GERRIT_CREDENTIALS_ID");
-        String gerritApiUrl = envVars.get("GERRIT_API_URL");
         String jsonPayload =
             "{\"path\": \""
                 + path

--- a/src/main/java/jenkins/plugins/gerrit/workflow/GerritReviewStep.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/GerritReviewStep.java
@@ -61,7 +61,15 @@ public class GerritReviewStep extends Step {
 
     @Override
     protected Void run() throws Exception {
+      String credentialsId = envVars.get("GERRIT_CREDENTIALS_ID");
+      String gerritApiUrl = envVars.get("GERRIT_API_URL");
       String branch = envVars.get("BRANCH_NAME");
+
+      if (gerritApiUrl == null) {
+        echo("GERRIT_API_URL is not available, disabling Gerrit integration");
+        return null;
+      }
+
       Pattern changeBranchPattern = Pattern.compile("([0-9][0-9])/([0-9]+)/([0-9]+)");
       Matcher matcher = changeBranchPattern.matcher(branch);
       if (matcher.matches()) {
@@ -69,8 +77,6 @@ public class GerritReviewStep extends Step {
         int patchsetId = Integer.parseInt(matcher.group(3));
         echo("Gerrit review change %d label %s / %d (%s)", changeId, label, score, message);
 
-        String credentialsId = envVars.get("GERRIT_CREDENTIALS_ID");
-        String gerritApiUrl = envVars.get("GERRIT_API_URL");
         String labels = label == null ? "" :
             "\"labels\":{\""
                 + label

--- a/src/test/java/jenkins/plugins/gerrit/workflow/GerritCommentStepTest.java
+++ b/src/test/java/jenkins/plugins/gerrit/workflow/GerritCommentStepTest.java
@@ -28,12 +28,27 @@ public class GerritCommentStepTest {
   @Rule public JenkinsRule j = new JenkinsRule();
 
   @Test
+  public void gerritCommentStepInvokeNoEnvTest() throws Exception {
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+        new CpsFlowDefinition(
+            "node {\n"
+                + "  gerritComment path: '/path/to/file', line: 1, message: 'Invalid spacing'\n"
+                + "}",
+            true));
+    WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    String log = JenkinsRule.getLog(run);
+    System.out.println(log);
+    assertTrue(log.contains("GERRIT_API_URL is not available"));
+  }
+
+  @Test
   public void gerritCommentStepInvokeTest() throws Exception {
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
         new CpsFlowDefinition(
             "node {\n"
-                + "  withEnv(['BRANCH_NAME=21/5621/1']) {\n"
+                + "  withEnv(['GERRIT_API_URL=https://host/a/project', 'BRANCH_NAME=21/5621/1']) {\n"
                 + "    gerritComment path: '/path/to/file', line: 1, message: 'Invalid spacing'\n"
                 + "  }\n"
                 + "}",

--- a/src/test/java/jenkins/plugins/gerrit/workflow/GerritReviewStepTest.java
+++ b/src/test/java/jenkins/plugins/gerrit/workflow/GerritReviewStepTest.java
@@ -28,12 +28,27 @@ public class GerritReviewStepTest {
   @Rule public JenkinsRule j = new JenkinsRule();
 
   @Test
+  public void gerritReviewStepInvokeNoEnvTest() throws Exception {
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(
+        new CpsFlowDefinition(
+            "node {\n"
+                + "  gerritReview label: 'Verified', score: -1, message: 'Does not work'\n"
+                + "}",
+            true));
+    WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    String log = JenkinsRule.getLog(run);
+    System.out.println(log);
+    assertTrue(log.contains("GERRIT_API_URL is not available"));
+  }
+
+  @Test
   public void gerritReviewStepInvokeTest() throws Exception {
     WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
     p.setDefinition(
         new CpsFlowDefinition(
             "node {\n"
-                + "  withEnv(['BRANCH_NAME=21/4321/1']) {\n"
+                + "  withEnv(['GERRIT_API_URL=https://host/a/project', 'BRANCH_NAME=21/4321/1']) {\n"
                 + "    gerritReview label: 'Verified', score: -1, message: 'Does not work'\n"
                 + "  }\n"
                 + "}",


### PR DESCRIPTION
Do not fail build if the pipeline runs in a context which has not Gerrit
environment.

Current behavior is a null pointer exception.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>