### PR TITLE
build: add google code format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,18 @@
           </rules>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
build fails if format does not pass

to format use:

    mvn com.coveo:fmt-maven-plugin:format

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>