### PR TITLE
workflow: fixup anonymous flow

### DIFF
--- a/src/main/java/jenkins/plugins/gerrit/GerritApiBuilder.java
+++ b/src/main/java/jenkins/plugins/gerrit/GerritApiBuilder.java
@@ -22,41 +22,9 @@ public class GerritApiBuilder {
   private PrintStream logger = System.out;
   private URIish gerritApiUrl;
   private Boolean insecureHttps;
+  private boolean allowAnonymous = true;
   private String username;
   private String password;
-
-  public static class AnonymousAuth implements GerritAuthData {
-    private final String gerritApiUrl;
-
-    public AnonymousAuth(String gerritApiUrl) {
-      this.gerritApiUrl = gerritApiUrl;
-    }
-
-    @Override
-    public String getLogin() {
-      return null;
-    }
-
-    @Override
-    public String getPassword() {
-      return null;
-    }
-
-    @Override
-    public boolean isHttpPassword() {
-      return false;
-    }
-
-    @Override
-    public String getHost() {
-      return gerritApiUrl;
-    }
-
-    @Override
-    public boolean isLoginAndPasswordAvailable() {
-      return false;
-    }
-  }
 
   public GerritApiBuilder logger(PrintStream logger) {
     this.logger = logger;
@@ -79,6 +47,11 @@ public class GerritApiBuilder {
 
   public GerritApiBuilder insecureHttps(Boolean insecureHttps) {
     this.insecureHttps = insecureHttps;
+    return this;
+  }
+
+  public GerritApiBuilder allowAnonymous(boolean allowAnonymous) {
+    this.allowAnonymous = allowAnonymous;
     return this;
   }
 
@@ -117,26 +90,26 @@ public class GerritApiBuilder {
 
   public GerritApi build() {
     GerritApi gerritApi = null;
-    List<HttpClientBuilderExtension> extensions = new ArrayList<>();
-    GerritAuthData authData = null;
     if (gerritApiUrl == null) {
       logger.println("Gerrit Review is disabled no API URL");
-    } else if (username == null) {
+    } else if (username == null && !allowAnonymous) {
       logger.println("Gerrit Review is disabled no credentials");
-      authData = new AnonymousAuth(gerritApiUrl.toString());
     } else {
-      authData = new GerritAuthData.Basic(gerritApiUrl.toString(), username, password);
+      List<HttpClientBuilderExtension> extensions = new ArrayList<>();
       if (Boolean.TRUE.equals(insecureHttps)) {
         extensions.add(SSLNoVerifyCertificateManagerClientBuilderExtension.INSTANCE);
       }
+      gerritApi =
+          new GerritRestApiFactory()
+              .create(
+                  new GerritAuthData.Basic(gerritApiUrl.toString(), username, password),
+                  extensions.toArray(new HttpClientBuilderExtension[0]));
     }
-    gerritApi =
-        new GerritRestApiFactory()
-            .create(authData, extensions.toArray(new HttpClientBuilderExtension[0]));
     return gerritApi;
   }
 
-  public boolean isAnonymous() {
-    return gerritApiUrl == null || username == null;
+  @Override
+  public String toString() {
+    return gerritApiUrl == null ? "null" : gerritApiUrl.toString();
   }
 }

--- a/src/main/java/jenkins/plugins/gerrit/workflow/GerritCommentStep.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/GerritCommentStep.java
@@ -63,26 +63,28 @@ public class GerritCommentStep extends Step {
 
     @Override
     protected Void run() throws Exception {
+      GerritApi gerritApi =
+          new GerritApiBuilder().stepContext(getContext()).allowAnonymous(false).build();
+      if (gerritApi == null) {
+        return null;
+      }
 
-      GerritApi gerritApi = new GerritApiBuilder().stepContext(getContext()).build();
-      if (gerritApi != null) {
-        GerritChange change = new GerritChange(getContext());
-        if (change.valid()) {
-          listener
-              .getLogger()
-              .format(
-                  "Gerrit review change %d/%d %s=%d (%s)%n",
-                  change.getChangeId(), change.getRevision(), path, line, message);
-          DraftInput draftInput = new DraftInput();
-          draftInput.path = path;
-          draftInput.line = line;
-          draftInput.message = message;
-          gerritApi
-              .changes()
-              .id(change.getChangeId())
-              .revision(change.getRevision())
-              .createDraft(draftInput);
-        }
+      GerritChange change = new GerritChange(getContext());
+      if (change.valid()) {
+        listener
+            .getLogger()
+            .format(
+                "Gerrit review change %d/%d %s=%d (%s)%n",
+                change.getChangeId(), change.getRevision(), path, line, message);
+        DraftInput draftInput = new DraftInput();
+        draftInput.path = path;
+        draftInput.line = line;
+        draftInput.message = message;
+        gerritApi
+            .changes()
+            .id(change.getChangeId())
+            .revision(change.getRevision())
+            .createDraft(draftInput);
       }
       return null;
     }

--- a/src/main/java/jenkins/plugins/gerrit/workflow/GerritReviewStep.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/GerritReviewStep.java
@@ -52,10 +52,9 @@ public class GerritReviewStep extends Step {
 
     @Override
     protected Void run() throws Exception {
-      GerritApiBuilder apiBuilder = new GerritApiBuilder().stepContext(getContext());
-      GerritApi gerritApi = apiBuilder.build();
-
-      if (apiBuilder.isAnonymous()) {
+      GerritApi gerritApi =
+          new GerritApiBuilder().stepContext(getContext()).allowAnonymous(false).build();
+      if (gerritApi == null) {
         return null;
       }
 

--- a/src/test/java/jenkins/plugins/gerrit/GerritApiBuilderTest.java
+++ b/src/test/java/jenkins/plugins/gerrit/GerritApiBuilderTest.java
@@ -31,4 +31,15 @@ public class GerritApiBuilderTest {
             .build();
     assertNotNull(restApi);
   }
+
+  @Test
+  public void testShouldNotWorkWithoutCredentials() throws URISyntaxException {
+    GerritApi restApi =
+        new GerritApiBuilder()
+            .gerritApiUrl("http://gerrit.mycompany.com")
+            .credentials(null, null)
+            .allowAnonymous(false)
+            .build();
+    assertNull(restApi);
+  }
 }


### PR DESCRIPTION
fix sequence of api creation, ssl should be handled regardless of
authentication.

move anonymous policy to builder instead of having an instance of builder.

no reason to have a special class for anonymous handling for the restapi.

sync the review and comment steps.

test credentials are available when interacting with gerrit.
    
Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>