### PR TITLE
Ignore failures of gerritReview on CloudBees CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,4 +6,20 @@
 
 // Test plugin compatbility to latest Jenkins LTS
 // Allow failing tests to retry execution
-buildPlugin(jenkinsVersions: [null, '2.60.1'], failFast: false)
+try {
+  buildPlugin(jenkinsVersions: [null, '2.60.1'], failFast: false, platforms: ['linux'])
+  if (currentBuild.result == 'UNSTABLE') {
+    review labels: [Verified: 0], message: "Build is unstable, there are failed tests ${env.BUILD_URL}"
+  } else {
+    review labels: [Verified: +1], message: "Build succeeded ${env.BUILD_URL}"
+  }
+} catch (e) {
+  review labels: [Verified: -1], message: "Build failed ${env.BUILD_URL}"
+}
+
+def review(labels, message) {
+  try {
+    gerritReview labels: labels, message: message
+  } catch (NoSuchMethodError e) {
+  }
+}


### PR DESCRIPTION
On the CloudBees hosted Jenkins CI the gerrit-code-review
plugin isn't installed and thus the gerritReview step is
not available.

Change-Id: I2c0721bbc1c57010ce4e1ab420517ff58651de64