### PR TITLE
Fix typo in GERRIT_REFNAME

### DIFF
--- a/src/main/java/jenkins/plugins/gerrit/GerritEnvironmentContributor.java
+++ b/src/main/java/jenkins/plugins/gerrit/GerritEnvironmentContributor.java
@@ -112,7 +112,7 @@ public class GerritEnvironmentContributor extends EnvironmentContributor {
             .findFirst()
             .get();
 
-    envs.put("$GERRIT_REFNAME", patchSetInfo.getValue().ref);
+    envs.put("GERRIT_REFNAME", patchSetInfo.getValue().ref);
     envs.put("GERRIT_PATCHSET_REVISION", patchSetInfo.getKey());
     envs.put("GERRIT_CHANGE_OWNER", change.owner.name + " <" + change.owner.email + ">");
     envs.put("GERRIT_CHANGE_OWNER_NAME", change.owner.name);


### PR DESCRIPTION
The environment variable name should not be prefixed with a '$'.