### PR TITLE
gerritComment: allow creating comments associated with a range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   </licenses>
 
   <artifactId>gerrit-code-review</artifactId>
-  <version>0.4.4</version>
+  <version>0.4.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Gerrit Code Review plugin</name>
   <description>Integrates Jenkins with Gerrit Code Review</description>
@@ -433,7 +433,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>gerrit-code-review-0.4.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   </licenses>
 
   <artifactId>gerrit-code-review</artifactId>
-  <version>0.4.4-SNAPSHOT</version>
+  <version>0.4.4</version>
   <packaging>hpi</packaging>
   <name>Gerrit Code Review plugin</name>
   <description>Integrates Jenkins with Gerrit Code Review</description>
@@ -433,7 +433,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>gerrit-code-review-0.4.4</tag>
   </scm>
 
   <pluginRepositories>

--- a/src/main/java/jenkins/plugins/gerrit/workflow/CommentFile.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/CommentFile.java
@@ -1,0 +1,33 @@
+package jenkins.plugins.gerrit.workflow;
+
+import com.google.gerrit.extensions.api.changes.DraftInput;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import javax.annotation.Nonnull;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class CommentFile extends CommentLocation {
+  @DataBoundConstructor
+  public CommentFile() {}
+
+  @Override
+  public String toString() {
+    return "File";
+  }
+
+  @Override
+  public void apply(DraftInput draftInput) {
+    draftInput.line = 0;
+  }
+
+  @Symbol("file")
+  @Extension
+  public static class DescriptorImpl extends Descriptor<CommentLocation> {
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+      return "Comment File";
+    }
+  }
+}

--- a/src/main/java/jenkins/plugins/gerrit/workflow/CommentLine.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/CommentLine.java
@@ -1,0 +1,37 @@
+package jenkins.plugins.gerrit.workflow;
+
+import com.google.gerrit.extensions.api.changes.DraftInput;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import javax.annotation.Nonnull;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class CommentLine extends CommentLocation {
+  private int line;
+
+  @DataBoundConstructor
+  public CommentLine(int line) {
+    this.line = line;
+  }
+
+  @Override
+  public void apply(DraftInput draftInput) {
+    draftInput.line = line;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Line:%s", line);
+  }
+
+  @Symbol("line")
+  @Extension
+  public static class DescriptorImpl extends Descriptor<CommentLocation> {
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+      return "Comment Line";
+    }
+  }
+}

--- a/src/main/java/jenkins/plugins/gerrit/workflow/CommentLocation.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/CommentLocation.java
@@ -1,0 +1,10 @@
+package jenkins.plugins.gerrit.workflow;
+
+import com.google.gerrit.extensions.api.changes.DraftInput;
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+
+public abstract class CommentLocation extends AbstractDescribableImpl<CommentLocation>
+    implements ExtensionPoint {
+  public abstract void apply(DraftInput draftInput);
+}

--- a/src/main/java/jenkins/plugins/gerrit/workflow/CommentRange.java
+++ b/src/main/java/jenkins/plugins/gerrit/workflow/CommentRange.java
@@ -1,0 +1,48 @@
+package jenkins.plugins.gerrit.workflow;
+
+import com.google.gerrit.extensions.api.changes.DraftInput;
+import com.google.gerrit.extensions.client.Comment;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import javax.annotation.Nonnull;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class CommentRange extends CommentLocation {
+  private int endCharacter;
+  private int endLine;
+  private int startCharacter;
+  private int startLine;
+
+  @DataBoundConstructor
+  public CommentRange(int startLine, int endLine, int startCharacter, int endCharacter) {
+    this.startLine = startLine;
+    this.endLine = endLine;
+    this.startCharacter = startCharacter;
+    this.endCharacter = endCharacter;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Range:%s-%s", startLine, endLine);
+  }
+
+  @Override
+  public void apply(DraftInput draftInput) {
+    draftInput.range = new Comment.Range();
+    draftInput.range.startLine = startLine;
+    draftInput.range.startCharacter = startCharacter;
+    draftInput.range.endLine = endLine;
+    draftInput.range.endCharacter = endCharacter;
+  }
+
+  @Symbol("range")
+  @Extension
+  public static class DescriptorImpl extends Descriptor<CommentLocation> {
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+      return "Comment Range";
+    }
+  }
+}

--- a/src/test/java/jenkins/plugins/gerrit/workflow/GerritCommentStepTest.java
+++ b/src/test/java/jenkins/plugins/gerrit/workflow/GerritCommentStepTest.java
@@ -38,12 +38,78 @@ public class GerritCommentStepTest {
   @Rule public JenkinsRule j = new JenkinsRule();
 
   @Test
-  public void gerritCommentStepInvokeTest() throws Exception {
-    int changeId = 4321;
-    int revision = 1;
+  public void gerritCommentWithLine() throws Exception {
     String path = "/path/to/file";
     int line = 1;
     String message = "Invalid spacing";
+
+    String gerritCommentScript =
+        String.format("gerritComment path: '%s', line: %s, message: '%s'", path, line, message);
+    DraftInput draftInput = new DraftInput();
+    draftInput.path = path;
+    draftInput.line = line;
+    draftInput.message = message;
+    gerritCommentTest(gerritCommentScript, JsonBody.json(draftInput));
+  }
+
+  @Test
+  public void gerritCommentWithLocationLine() throws Exception {
+    String path = "/path/to/file";
+    int line = 1;
+    String message = "Invalid spacing";
+
+    String gerritCommentScript =
+        String.format(
+            "gerritComment path: '%s', location: [$class: 'CommentLine', line: %s], message: '%s'",
+            path, line, message);
+    DraftInput draftInput = new DraftInput();
+    draftInput.path = path;
+    draftInput.line = line;
+    draftInput.message = message;
+    gerritCommentTest(gerritCommentScript, JsonBody.json(draftInput));
+  }
+
+  @Test
+  public void gerritCommentWithLocationFile() throws Exception {
+    String path = "/path/to/file";
+    int line = 0;
+    String message = "Invalid spacing";
+
+    String gerritCommentScript =
+        String.format(
+            "gerritComment path: '%s', location: [$class: 'CommentFile'], message: '%s'",
+            path, message);
+    DraftInput draftInput = new DraftInput();
+    draftInput.path = path;
+    draftInput.line = line;
+    draftInput.message = message;
+    gerritCommentTest(gerritCommentScript, JsonBody.json(draftInput));
+  }
+
+  @Test
+  public void gerritCommentWithLocationRange() throws Exception {
+    String path = "/path/to/file";
+    String message = "Invalid spacing";
+
+    String gerritCommentScript =
+        String.format(
+            "gerritComment path: '%s', message: '%s', location: [$class: 'CommentRange', startLine: 1,"
+                + " endLine: 2, startCharacter: 3, endCharacter: 4]",
+            path, message);
+    // We cannot use DraftInput, as Range would get serialized to JSON with an extra property
+    // 'isValid'
+    gerritCommentTest(
+        gerritCommentScript,
+        JsonBody.json(
+            "{\"path\":\"/path/to/file\",\"range\":{"
+                + "\"start_line\":1,\"start_character\":3,\"end_line\":2,\"end_character\":4},"
+                + "\"message\":\"Invalid spacing\"}"));
+  }
+
+  private void gerritCommentTest(String gerritCommentScript, JsonBody commentBody)
+      throws Exception {
+    int changeId = 4321;
+    int revision = 1;
     String branch = String.format("%02d/%d/%d", changeId % 100, changeId, revision);
 
     UsernamePasswordCredentialsImpl c =
@@ -65,28 +131,22 @@ public class GerritCommentStepTest {
                     + "    'GERRIT_CREDENTIALS_ID=cid',\n"
                     + "    'BRANCH_NAME=%s',\n"
                     + "  ]) {\n"
-                    + "    gerritComment path: '%s', line: %s, message: '%s'\n"
+                    + "    %s\n"
                     + "  }\n"
                     + "}",
                 g.getClient().remoteAddress().getHostString(),
                 g.getClient().remoteAddress().getPort(),
                 branch,
-                path,
-                line,
-                message),
+                gerritCommentScript),
             true));
 
-    DraftInput draftInput = new DraftInput();
-    draftInput.path = path;
-    draftInput.line = line;
-    draftInput.message = message;
     g.getClient()
         .when(
             HttpRequest.request(
                     String.format(
                         "/a/project/a/changes/%s/revisions/%s/drafts", changeId, revision))
                 .withMethod("PUT")
-                .withBody(JsonBody.json(draftInput)))
+                .withBody(commentBody))
         .respond(
             HttpResponse.response()
                 .withStatusCode(200)


### PR DESCRIPTION
Range is specified through the location parameter, which can be set
either to a file, line or range:

 gerritComment location: file(), message: '...'
 gerritComment location: line(23), message: '...'
 gerritComment location: range(startLine: 3, endLine: 7), message: '...'

To ensure backwards compatibility, line can also still be set directly:

 gerritComment line: 23, message: '...'