### PR TITLE
Expose GERRIT_REFSPEC variable, like gerrit-trigger

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -102,7 +102,8 @@ Gerrit using RestAPI.
 |GERRIT_PATCHSET_UPLOADER        |Uploader (name <email>) of the Gerrit patch-set                 |
 |GERRIT_PATCHSET_UPLOADER_NAME   |Uploader name of the Gerrit patch-set                           |
 |GERRIT_PATCHSET_UPLOADER_EMAIL  |Uploader e-mail of the Gerrit patch-set                         |
-|GERRIT_REFNAME                  |Git ref name of the change/patch-set                        |
+|GERRIT_REFNAME                  |Git ref name of the change/patch-set                            |
+|GERRIT_REFSPEC                  |Git ref name of the change/patch-set                            |
 
 When the Jenkinsfile is discovered through a multi-branch pipeline, the above environment
 variables related to Gerrit and the associated change/patch-set would be automatically

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   </licenses>
 
   <artifactId>gerrit-code-review</artifactId>
-  <version>0.4.4</version>
+  <version>0.4.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Gerrit Code Review plugin</name>
   <description>Integrates Jenkins with Gerrit Code Review</description>
@@ -433,7 +433,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>gerrit-code-review-0.4.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   </licenses>
 
   <artifactId>gerrit-code-review</artifactId>
-  <version>0.4.4-SNAPSHOT</version>
+  <version>0.4.4</version>
   <packaging>hpi</packaging>
   <name>Gerrit Code Review plugin</name>
   <description>Integrates Jenkins with Gerrit Code Review</description>
@@ -433,7 +433,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>gerrit-code-review-0.4.4</tag>
   </scm>
 
   <pluginRepositories>

--- a/src/main/java/jenkins/plugins/gerrit/GerritEnvironmentContributor.java
+++ b/src/main/java/jenkins/plugins/gerrit/GerritEnvironmentContributor.java
@@ -120,6 +120,7 @@ public class GerritEnvironmentContributor extends EnvironmentContributor {
             .get();
 
     envs.put("GERRIT_REFNAME", patchSetInfo.getValue().ref);
+    envs.put("GERRIT_REFSPEC", patchSetInfo.getValue().ref);
     envs.put("GERRIT_PATCHSET_REVISION", patchSetInfo.getKey());
     envs.put("GERRIT_CHANGE_OWNER", change.owner.name + " <" + change.owner.email + ">");
     envs.put("GERRIT_CHANGE_OWNER_NAME", change.owner.name);


### PR DESCRIPTION
In gerrit-trigger, the ref name is exposed through the GERRIT_REFSPEC variable,
while GERRIT_REFNAME is exposed only for 'Reference Updated' events.