### PR TITLE
encode null email-id to empty string

### DIFF
--- a/src/main/java/jenkins/plugins/gerrit/GerritEnvironmentContributor.java
+++ b/src/main/java/jenkins/plugins/gerrit/GerritEnvironmentContributor.java
@@ -139,12 +139,12 @@ public class GerritEnvironmentContributor extends EnvironmentContributor {
     envs.put("GERRIT_PATCHSET_REVISION", patchSetInfo.getKey());
     envs.put("GERRIT_CHANGE_OWNER", change.owner.name + " <" + change.owner.email + ">");
     envs.put("GERRIT_CHANGE_OWNER_NAME", change.owner.name);
-    envs.put("GERRIT_CHANGE_OWNER_EMAIL", change.owner.email);
+    envs.put("GERRIT_CHANGE_OWNER_EMAIL", nullToEmpty(change.owner.email));
 
     AccountInfo uploader = patchSetInfo.getValue().uploader;
     envs.put("GERRIT_PATCHSET_UPLOADER", uploader.name + " <" + uploader.email + ">");
     envs.put("GERRIT_PATCHSET_UPLOADER_NAME", uploader.name);
-    envs.put("GERRIT_PATCHSET_UPLOADER_EMAIL", uploader.email);
+    envs.put("GERRIT_PATCHSET_UPLOADER_EMAIL", nullToEmpty(uploader.email));
   }
 
   private String booleanString(Boolean booleanValue) {


### PR DESCRIPTION
Gerrit user without an email ID is a valid case. Changes from such users will result in the following Jenkins exception.
java.lang.IllegalArgumentException: Null value not allowed as an environment variable: GERRIT_CHANGE_OWNER_EMAIL

Signed-off-by: Manjunatha Shetty <manjunath.anna@gmail.com>

<!-- Please describe your pull request here. -->
encode null email-id to empty string
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ x+] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
