### PR TITLE
[JENKINS-68879] Avoid ChangeInfo serialisation to prevent JEP-200 issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ Registry since April 2018 and has been used so far by hundreds of
 developers around the world that provided already very useful feedback
 and started contributing with pull-requests.
 
+### v0.4.8 - Released - 24 June 2023
+
+#### Fixes
+
+- [JENKINS-68879](https://issues.jenkins.io/browse/JENKINS-68879) Avoid ChangeInfo serialization for compliance with JEP-200
+
 ### v0.4.7 - Released - 6 Sep 2021
 
 #### Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,12 @@
       <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.0.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <scm>

--- a/src/main/java/jenkins/plugins/gerrit/GerritEnvironmentContributor.java
+++ b/src/main/java/jenkins/plugins/gerrit/GerritEnvironmentContributor.java
@@ -14,6 +14,7 @@
 
 package jenkins.plugins.gerrit;
 
+import com.google.common.base.Strings;
 import com.google.gerrit.extensions.common.AccountInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.RevisionInfo;
@@ -26,6 +27,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,10 +45,55 @@ public class GerritEnvironmentContributor extends EnvironmentContributor {
       Pattern.compile("^\\d+\\/(?<changeNum>\\d+)\\/(?<patchSet>\\d+)$");
 
   public static class ChangeInfoInvisibleAction extends InvisibleAction {
-    Optional<ChangeInfo> maybeChangeInfo;
+    private final Map<String, String> changeEnvs;
 
-    ChangeInfoInvisibleAction(Optional<ChangeInfo> maybeChangeInfo) {
-      this.maybeChangeInfo = maybeChangeInfo;
+    ChangeInfoInvisibleAction(
+        Optional<ChangeInfo> maybeChangeInfo, int patchSetNum, GerritURI gerritURI) {
+      changeEnvs = new HashMap<>();
+
+      maybeChangeInfo.ifPresent(
+          (change) -> {
+            changeEnvs.put("GERRIT_CHANGE_NUMBER", Integer.toString(change._number));
+            changeEnvs.put("GERRIT_PATCHSET_NUMBER", Integer.toString(patchSetNum));
+            changeEnvs.put(
+                "GERRIT_CHANGE_PRIVATE_STATE",
+                change.isPrivate != null ? Boolean.toString(change.isPrivate) : "false");
+            changeEnvs.put(
+                "GERRIT_CHANGE_WIP_STATE",
+                change.workInProgress != null ? Boolean.toString(change.workInProgress) : "false");
+            changeEnvs.put("GERRIT_CHANGE_SUBJECT", change.subject);
+            changeEnvs.put(
+                "GERRIT_CHANGE_URL", gerritURI.setPath("" + change._number).toASCIIString());
+            changeEnvs.put("GERRIT_BRANCH", change.branch);
+            changeEnvs.put("GERRIT_TOPIC", Strings.nullToEmpty(change.topic));
+            changeEnvs.put("GERRIT_CHANGE_ID", change.id);
+
+            Map.Entry<String, RevisionInfo> patchSetInfo =
+                change
+                    .revisions
+                    .entrySet()
+                    .stream()
+                    .filter(entry -> entry.getValue()._number == patchSetNum)
+                    .findFirst()
+                    .get();
+
+            changeEnvs.put("GERRIT_REFNAME", patchSetInfo.getValue().ref);
+            changeEnvs.put("GERRIT_REFSPEC", patchSetInfo.getValue().ref);
+            changeEnvs.put("GERRIT_PATCHSET_REVISION", patchSetInfo.getKey());
+            changeEnvs.put(
+                "GERRIT_CHANGE_OWNER", change.owner.name + " <" + change.owner.email + ">");
+            changeEnvs.put("GERRIT_CHANGE_OWNER_NAME", change.owner.name);
+            changeEnvs.put("GERRIT_CHANGE_OWNER_EMAIL", change.owner.email);
+
+            AccountInfo uploader = patchSetInfo.getValue().uploader;
+            changeEnvs.put("GERRIT_PATCHSET_UPLOADER", uploader.name + " <" + uploader.email + ">");
+            changeEnvs.put("GERRIT_PATCHSET_UPLOADER_NAME", uploader.name);
+            changeEnvs.put("GERRIT_PATCHSET_UPLOADER_EMAIL", uploader.email);
+          });
+    }
+
+    public Map<String, String> getChangeEnvs() {
+      return changeEnvs;
     }
   }
 
@@ -87,64 +134,21 @@ public class GerritEnvironmentContributor extends EnvironmentContributor {
     if (matcher.find()) {
       int patchSetNum = Integer.parseInt(matcher.group("patchSet"));
 
-      Optional<ChangeInfo> changeInfo = Optional.empty();
+      Map<String, String> changeEnvs;
       List<ChangeInfoInvisibleAction> changeInfos = r.getActions(ChangeInfoInvisibleAction.class);
       if (changeInfos.isEmpty()) {
-        changeInfo = gerritSCMSource.getChangeInfo(Integer.parseInt(matcher.group("changeNum")));
-        r.addAction(new ChangeInfoInvisibleAction(changeInfo));
+        int changeNumber = Integer.parseInt(matcher.group("changeNum"));
+        Optional<ChangeInfo> changeInfo = gerritSCMSource.getChangeInfo(changeNumber);
+        ChangeInfoInvisibleAction changeInfoAction =
+            new ChangeInfoInvisibleAction(changeInfo, patchSetNum, gerritURI);
+        r.addAction(changeInfoAction);
+        changeEnvs = changeInfoAction.getChangeEnvs();
       } else {
-        changeInfo = changeInfos.get(0).maybeChangeInfo;
+        changeEnvs = changeInfos.get(0).getChangeEnvs();
       }
-      changeInfo.ifPresent(
-          (change) -> {
-            publishChangeDetails(
-                envs,
-                matcher.group("changeNum"),
-                matcher.group("patchSet"),
-                patchSetNum,
-                change,
-                gerritURI);
-          });
+
+      envs.putAll(changeEnvs);
     }
-  }
-
-  private void publishChangeDetails(
-      @Nonnull EnvVars envs,
-      String changeNum,
-      String patchSet,
-      int patchSetNum,
-      ChangeInfo change,
-      GerritURI gerritURI) {
-    envs.put("GERRIT_CHANGE_NUMBER", changeNum);
-    envs.put("GERRIT_PATCHSET_NUMBER", patchSet);
-    envs.put("GERRIT_CHANGE_PRIVATE_STATE", booleanString(change.isPrivate));
-    envs.put("GERRIT_CHANGE_WIP_STATE", booleanString(change.workInProgress));
-    envs.put("GERRIT_CHANGE_SUBJECT", change.subject);
-    envs.put("GERRIT_CHANGE_URL", gerritURI.setPath("" + change._number).toASCIIString());
-    envs.put("GERRIT_BRANCH", change.branch);
-    envs.put("GERRIT_TOPIC", nullToEmpty(change.topic));
-    envs.put("GERRIT_CHANGE_ID", change.id);
-
-    Map.Entry<String, RevisionInfo> patchSetInfo =
-        change
-            .revisions
-            .entrySet()
-            .stream()
-            .filter(entry -> entry.getValue()._number == patchSetNum)
-            .findFirst()
-            .get();
-
-    envs.put("GERRIT_REFNAME", patchSetInfo.getValue().ref);
-    envs.put("GERRIT_REFSPEC", patchSetInfo.getValue().ref);
-    envs.put("GERRIT_PATCHSET_REVISION", patchSetInfo.getKey());
-    envs.put("GERRIT_CHANGE_OWNER", change.owner.name + " <" + change.owner.email + ">");
-    envs.put("GERRIT_CHANGE_OWNER_NAME", change.owner.name);
-    envs.put("GERRIT_CHANGE_OWNER_EMAIL", change.owner.email);
-
-    AccountInfo uploader = patchSetInfo.getValue().uploader;
-    envs.put("GERRIT_PATCHSET_UPLOADER", uploader.name + " <" + uploader.email + ">");
-    envs.put("GERRIT_PATCHSET_UPLOADER_NAME", uploader.name);
-    envs.put("GERRIT_PATCHSET_UPLOADER_EMAIL", uploader.email);
   }
 
   private String booleanString(Boolean booleanValue) {

--- a/src/test/java/jenkins/plugins/gerrit/GerritEnvironmentContributorTest.java
+++ b/src/test/java/jenkins/plugins/gerrit/GerritEnvironmentContributorTest.java
@@ -1,0 +1,145 @@
+// Copyright (C) 2023 GerritForge Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jenkins.plugins.gerrit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.ChangeInfo;
+import com.google.gerrit.extensions.common.RevisionInfo;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import jenkins.plugins.gerrit.GerritEnvironmentContributor.ChangeInfoInvisibleAction;
+import org.eclipse.jgit.transport.URIish;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GerritEnvironmentContributorTest {
+
+  public static final String TEST_PROJECT_NAME = "myproject";
+  public static final AccountInfo TEST_ACCOUNT_INFO_JOHN_DOE =
+      new AccountInfo("John Doe", "john.doe@mycompany.com");
+  public static final String TEST_BRANCH = "mybranch";
+  public static final String TEST_CHANGE_SUBJECT = "This is a test change";
+  public static final String TEST_CHANGE_TOPIC = "test-topic";
+  public static final String TEST_CHANGE_ID = "I2ff60b01ab0e2305fdf8739cd884038091f2b888";
+  public static final String TEST_CHANGE_ID_TRIPLET =
+      TEST_PROJECT_NAME + "~" + TEST_BRANCH + "~" + TEST_CHANGE_ID;
+  public static final int TEST_PATCHSET_NUMBER = 2;
+  public static final int TEST_CHANGE_NUMBER = 1;
+  public static final String TEST_CHANGE_REF_NAME =
+      "refs/changes/"
+          + String.format("%02d", TEST_CHANGE_NUMBER)
+          + "/"
+          + TEST_CHANGE_NUMBER
+          + "/"
+          + TEST_PATCHSET_NUMBER;
+  public static final AccountInfo TEST_ACCOUNT_INFO_MATT_SMITH =
+      new AccountInfo("Matt Smith", "matt.smith@mycompany.com");
+  public static final String TEST_GERRIT_URL = "http://gerrit.mycompany.com";
+  private ChangeInfo changeInfo;
+  private GerritURI gerritURI;
+
+  @Before
+  public void setup() throws URISyntaxException {
+    changeInfo =
+        new ChangeInfo() {
+          {
+            this._number = TEST_CHANGE_NUMBER;
+            this.project = TEST_PROJECT_NAME;
+            this.owner = TEST_ACCOUNT_INFO_JOHN_DOE;
+            this.branch = TEST_BRANCH;
+            this.subject = TEST_CHANGE_SUBJECT;
+            this.topic = TEST_CHANGE_TOPIC;
+            this.changeId = TEST_CHANGE_ID;
+            this.id = TEST_CHANGE_ID_TRIPLET;
+            this.revisions =
+                new HashMap<String, RevisionInfo>() {
+                  {
+                    put(
+                        Integer.toString(TEST_PATCHSET_NUMBER),
+                        new RevisionInfo() {
+                          {
+                            this._number = TEST_PATCHSET_NUMBER;
+                            this.uploader = TEST_ACCOUNT_INFO_MATT_SMITH;
+                            this.ref = TEST_CHANGE_REF_NAME;
+                          }
+                        });
+                  }
+                };
+          }
+        };
+    gerritURI = new GerritURI(new URIish(TEST_GERRIT_URL));
+  }
+
+  @Test
+  public void testBuildEnvironmentForChangeInfo() throws Exception {
+    Map<String, String> changeEnvs =
+        new ChangeInfoInvisibleAction(Optional.of(changeInfo), TEST_PATCHSET_NUMBER, gerritURI)
+            .getChangeEnvs();
+    Map<String, String> expectedMap =
+        new HashMap<String, String>() {
+          {
+            put("GERRIT_BRANCH", TEST_BRANCH);
+            put("GERRIT_PATCHSET_UPLOADER_NAME", TEST_ACCOUNT_INFO_MATT_SMITH.name);
+            put(
+                "GERRIT_CHANGE_OWNER",
+                TEST_ACCOUNT_INFO_JOHN_DOE.name + " <" + TEST_ACCOUNT_INFO_JOHN_DOE.email + ">");
+            put("GERRIT_CHANGE_OWNER_NAME", TEST_ACCOUNT_INFO_JOHN_DOE.name);
+            put("GERRIT_CHANGE_OWNER_EMAIL", TEST_ACCOUNT_INFO_JOHN_DOE.email);
+            put(
+                "GERRIT_PATCHSET_UPLOADER",
+                TEST_ACCOUNT_INFO_MATT_SMITH.name
+                    + " <"
+                    + TEST_ACCOUNT_INFO_MATT_SMITH.email
+                    + ">");
+            put("GERRIT_PATCHSET_UPLOADER_NAME", TEST_ACCOUNT_INFO_MATT_SMITH.name);
+            put("GERRIT_PATCHSET_UPLOADER_EMAIL", TEST_ACCOUNT_INFO_MATT_SMITH.email);
+            put("GERRIT_CHANGE_SUBJECT", TEST_CHANGE_SUBJECT);
+            put("GERRIT_TOPIC", TEST_CHANGE_TOPIC);
+            put("GERRIT_REFNAME", TEST_CHANGE_REF_NAME);
+            put("GERRIT_CHANGE_URL", TEST_GERRIT_URL + "/" + TEST_CHANGE_NUMBER);
+            put("GERRIT_CHANGE_NUMBER", Integer.toString(TEST_CHANGE_NUMBER));
+            put("GERRIT_PATCHSET_REVISION", Integer.toString(TEST_PATCHSET_NUMBER));
+            put("GERRIT_PATCHSET_NUMBER", Integer.toString(TEST_PATCHSET_NUMBER));
+            put("GERRIT_CHANGE_WIP_STATE", "false");
+            put("GERRIT_CHANGE_ID", TEST_CHANGE_ID_TRIPLET);
+            put("GERRIT_CHANGE_PRIVATE_STATE", "false");
+            put("GERRIT_REFSPEC", TEST_CHANGE_REF_NAME);
+          }
+        };
+    assertThat(changeEnvs).containsExactlyEntriesIn(expectedMap);
+  }
+
+  @Test
+  public void testBuildEnvironmentForPrivateChange() {
+    changeInfo.isPrivate = true;
+    assertThat(
+            new ChangeInfoInvisibleAction(Optional.of(changeInfo), TEST_PATCHSET_NUMBER, gerritURI)
+                .getChangeEnvs())
+        .containsEntry("GERRIT_CHANGE_PRIVATE_STATE", "true");
+  }
+
+  @Test
+  public void testBuildEnvironmentForWipChange() {
+    changeInfo.workInProgress = true;
+    assertThat(
+            new ChangeInfoInvisibleAction(Optional.of(changeInfo), TEST_PATCHSET_NUMBER, gerritURI)
+                .getChangeEnvs())
+        .containsEntry("GERRIT_CHANGE_WIP_STATE", "true");
+  }
+}


### PR DESCRIPTION
The JEP-200 has introduced stricter control on serialisation which would require the explicit listing of all classes references by ChangeInfo, including the internal implementation details of the actual runtime classes of the Maps used in Gerrit Client APIs.

Prevent all the serialisation issues by resolving the extraction of change-related variable names and store them in plain Java's HashMaps of <String,String> for serialisation.

P.S. Even if Guava may have helped, use JVM-only provided classes that won't require any class serialisation on the Jenkins agent side.

Change-Id: I26c4a7c1a30c3845bb7620be7b9c963bbea62d47

### Testing done

This has been tested E2E with Jenkins 2.375.2 and a remote Docker agent.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

